### PR TITLE
Remove unknown option github_style

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,7 +144,6 @@ html_theme_options = {
     'github_user': 'aio-libs',
     'github_repo': 'aiohttp_security',
     'github_button': True,
-    'github_style': 'star',
     'github_banner': True,
     'travis_button': True,
     'codecov_button': True,


### PR DESCRIPTION
The option `github_style` doesn't appear to exist in the Alabaster theme being used. This causes `make doc` to fail. Removing the unknown option fixes the problem.