### PR TITLE
Remove unsupported docs theme option

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,7 +144,6 @@ html_theme_options = {
     'github_user': 'aio-libs',
     'github_repo': 'aiohttp_security',
     'github_button': True,
-    'github_style': 'star',
     'github_banner': True,
     'travis_button': True,
     'codecov_button': True,


### PR DESCRIPTION
```
$ make doc
...
preparing documents... 
Theme error:
unsupported theme option 'github_style' given
make[1]: *** [html] Error 1

```
`github_style` option is not supported in `alabaster` theme -- [proof](https://github.com/bitprophet/alabaster/blob/42eaa8e8ebfa725ef5c79de95dd42f6a8fb6b6d0/alabaster/theme.conf#L6)