### PR TITLE
aiohttp_session not required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - 3.4
+  - 3.4.3
   - 3.5
   - nightly
 

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,11 @@ To install type ``pip install aiohttp_security``.
 Launch ``make doc`` and see examples or look under **demo** directory for a
 sample project.
 
+Documentation
+-------------
+
+https://aiohttp-security.readthedocs.io/
+
 Develop
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,9 @@
 aiohttp_security
 ================
+.. image:: https://travis-ci.org/aio-libs/aiohttp-security.svg?branch=master
+    :target: https://travis-ci.org/aio-libs/aiohttp-security
+.. image:: https://codecov.io/github/aio-libs/aiohttp-security/coverage.svg?branch=master
+    :target: https://codecov.io/github/aio-libs/aiohttp-security
 
 The library provides identity and autorization for `aiohttp.web`__.
 

--- a/aiohttp_security/session_identity.py
+++ b/aiohttp_security/session_identity.py
@@ -6,7 +6,11 @@ to configure aiohttp_session properly.
 
 import asyncio
 
-from aiohttp_session import get_session
+try:
+    from aiohttp_session import get_session
+    has_aiohttp_session = True
+except ImportError:
+    has_aiohttp_session = False
 
 from .abc import AbstractIdentityPolicy
 
@@ -15,6 +19,10 @@ class SessionIdentityPolicy(AbstractIdentityPolicy):
 
     def __init__(self, session_key='AIOHTTP_SECURITY'):
         self._session_key = session_key
+
+        if not has_aiohttp_session:
+            raise ImportError(
+                'SessionIdentityPolicy requires aiohttp_session')
 
     @asyncio.coroutine
     def identify(self, request):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -144,7 +144,6 @@ html_theme_options = {
     'github_user': 'aio-libs',
     'github_repo': 'aiohttp_security',
     'github_button': True,
-    'github_style': 'star',
     'github_banner': True,
     'travis_button': True,
     'codecov_button': True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,7 +142,7 @@ html_theme_options = {
     'logo': 'aiohttp-icon-128x128.png',
     'description': 'Authorization and identity for aoihttp',
     'github_user': 'aio-libs',
-    'github_repo': 'aiohttp_security',
+    'github_repo': 'aiohttp-security',
     'github_button': True,
     'github_banner': True,
     'travis_button': True,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ flake8==3.2.1
 pytest==3.0.6
 pytest-cov==2.4.0
 coverage==4.3.4
-sphinx==1.5.1
+sphinx==1.5.2
 pep257==0.7.0
 aiohttp-session==0.8.0
 aiopg[sa]==0.13.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -e .
 flake8==3.2.1
-pytest==3.0.5
+pytest==3.0.6
 pytest-cov==2.4.0
 coverage==4.3.4
 sphinx==1.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 flake8==3.2.1
 pytest==3.0.5
 pytest-cov==2.4.0
-coverage==4.3
+coverage==4.3.4
 sphinx==1.5.1
 pep257==0.7.0
 aiohttp-session==0.8.0


### PR DESCRIPTION
If you want use only `CookiesIdentityPolicy`, you still must install `aiohttp-session` (with `aioredis`, `cryptography`, `pynacl`, etc.) for `SessionIdentityPolicy`. I think it is redundant.

/cc @asvetlov, @jettify 