### PR TITLE
aiohttp_session is not required

### DIFF
--- a/aiohttp_security/session_identity.py
+++ b/aiohttp_security/session_identity.py
@@ -6,7 +6,11 @@ to configure aiohttp_session properly.
 
 import asyncio
 
-from aiohttp_session import get_session
+try:
+    from aiohttp_session import get_session
+    has_aiohttp_session = True
+except ImportError:
+    has_aiohttp_session = False
 
 from .abc import AbstractIdentityPolicy
 
@@ -15,6 +19,10 @@ class SessionIdentityPolicy(AbstractIdentityPolicy):
 
     def __init__(self, session_key='AIOHTTP_SECURITY'):
         self._session_key = session_key
+
+        if not has_aiohttp_session:
+            raise ImportError(
+                'SessionIdentityPolicy requires aiohttp_session')
 
     @asyncio.coroutine
     def identify(self, request):


### PR DESCRIPTION
If you want use only `CookiesIdentityPolicy`, you still must install `aiohttp-session` (with `aioredis`, `cryptography`, `pynacl`, etc.) for `SessionIdentityPolicy`. I think it is redundant.

/cc @jettify 