### PR TITLE
`aiohttp-session` is not required

### DIFF
--- a/aiohttp_security/session_identity.py
+++ b/aiohttp_security/session_identity.py
@@ -8,9 +8,9 @@ import asyncio
 
 try:
     from aiohttp_session import get_session
-    has_aiohttp_session = True
+    HAS_AIOHTTP_SESSION = True
 except ImportError:  # pragma: no cover
-    has_aiohttp_session = False
+    HAS_AIOHTTP_SESSION = False
 
 from .abc import AbstractIdentityPolicy
 
@@ -20,7 +20,7 @@ class SessionIdentityPolicy(AbstractIdentityPolicy):
     def __init__(self, session_key='AIOHTTP_SECURITY'):
         self._session_key = session_key
 
-        if not has_aiohttp_session:  # pragma: no cover
+        if not HAS_AIOHTTP_SESSION:  # pragma: no cover
             raise ImportError(
                 'SessionIdentityPolicy requires `aiohttp_session`')
 

--- a/aiohttp_security/session_identity.py
+++ b/aiohttp_security/session_identity.py
@@ -6,7 +6,11 @@ to configure aiohttp_session properly.
 
 import asyncio
 
-from aiohttp_session import get_session
+try:
+    from aiohttp_session import get_session
+    has_aiohttp_session = True
+except ImportError:
+    has_aiohttp_session = False
 
 from .abc import AbstractIdentityPolicy
 
@@ -15,6 +19,10 @@ class SessionIdentityPolicy(AbstractIdentityPolicy):
 
     def __init__(self, session_key='AIOHTTP_SECURITY'):
         self._session_key = session_key
+
+        if not has_aiohttp_session:
+            raise ImportError(
+                'SessionIdentityPolicy requires `aiohttp_session`')
 
     @asyncio.coroutine
     def identify(self, request):

--- a/aiohttp_security/session_identity.py
+++ b/aiohttp_security/session_identity.py
@@ -9,7 +9,7 @@ import asyncio
 try:
     from aiohttp_session import get_session
     has_aiohttp_session = True
-except ImportError:
+except ImportError:  # pragma: no cover
     has_aiohttp_session = False
 
 from .abc import AbstractIdentityPolicy
@@ -20,7 +20,7 @@ class SessionIdentityPolicy(AbstractIdentityPolicy):
     def __init__(self, session_key='AIOHTTP_SECURITY'):
         self._session_key = session_key
 
-        if not has_aiohttp_session:
+        if not has_aiohttp_session:  # pragma: no cover
             raise ImportError(
                 'SessionIdentityPolicy requires `aiohttp_session`')
 


### PR DESCRIPTION
Fixed this case:
```
$ pip install aiohttp-security
...
$ python3
>>> import aiohttp_security
...
ImportError: No module named 'aiohttp_session'
```

Another [solution](https://github.com/aio-libs/aiohttp-security/pull/39/files) — throw error during `SessionIdentityPolicy` init