### PR TITLE
Add has permission class decorator

### DIFF
--- a/aiohttp_security/__init__.py
+++ b/aiohttp_security/__init__.py
@@ -1,5 +1,6 @@
 from .abc import AbstractAuthorizationPolicy, AbstractIdentityPolicy
-from .api import (authorized_userid, forget, has_permission, is_anonymous,
+from .api import (authorized_userid, forget, has_permission,
+                  class_has_permission, is_anonymous,
                   login_required, permits, remember, setup)
 from .cookies_identity import CookiesIdentityPolicy
 from .session_identity import SessionIdentityPolicy
@@ -11,4 +12,4 @@ __all__ = ('AbstractIdentityPolicy', 'AbstractAuthorizationPolicy',
            'CookiesIdentityPolicy', 'SessionIdentityPolicy',
            'remember', 'forget', 'authorized_userid',
            'permits', 'setup', 'is_anonymous',
-           'login_required', 'has_permission')
+           'login_required', 'has_permission', 'class_has_permission')

--- a/aiohttp_security/api.py
+++ b/aiohttp_security/api.py
@@ -92,13 +92,18 @@ def login_required(fn):
     User is considered authorized if authorized_userid
     returns some value.
     """
+
     @wraps(fn)
     async def wrapped(*args, **kwargs):
         request = args[-1]
-        if not isinstance(request, web.BaseRequest):
+        if isinstance(request, web.View):
+            request = request.request
+        elif not isinstance(request, web.BaseRequest):
             msg = ("Incorrect decorator usage. "
                    "Expecting `def handler(request)` "
-                   "or `def handler(self, request)`.")
+                   "`def handler(self, request)` or "
+                   "`def handler(self)` if handler is "
+                   "a web.View subclasse method.")
             raise RuntimeError(msg)
 
         userid = await authorized_userid(request)
@@ -123,13 +128,18 @@ def has_permission(
     raises HTTPForbidden.
     """
     def wrapper(fn):
+
         @wraps(fn)
         async def wrapped(*args, **kwargs):
             request = args[-1]
-            if not isinstance(request, web.BaseRequest):
+            if isinstance(request, web.View):
+                request = request.request
+            elif not isinstance(request, web.BaseRequest):
                 msg = ("Incorrect decorator usage. "
                        "Expecting `def handler(request)` "
-                       "or `def handler(self, request)`.")
+                       "`def handler(self, request)` or "
+                       "`def handler(self)` if handler is "
+                       "a web.View subclasse method.")
                 raise RuntimeError(msg)
 
             userid = await authorized_userid(request)

--- a/tests/test_class_has_permission.py
+++ b/tests/test_class_has_permission.py
@@ -1,0 +1,138 @@
+from aiohttp import web
+from aiohttp_security import setup as _setup
+from aiohttp_security import (AbstractAuthorizationPolicy,
+                              forget, class_has_permission,
+                              remember)
+from aiohttp_security.cookies_identity import CookiesIdentityPolicy
+
+
+class Autz(AbstractAuthorizationPolicy):
+
+    user_permission_map = {
+        'user_1': {'bike.read'},
+        'user_2': {'bike.create'},
+        'user_3': {'bike.update'},
+        'user_4': {'bike.delete'}
+    }
+
+    async def permits(self, identity, permission, context=None):
+        if identity in self.user_permission_map:
+            return permission in self.user_permission_map[identity]
+        else:
+            return False
+
+    async def authorized_userid(self, identity):
+        if identity in self.user_permission_map:
+            return identity
+        else:
+            return None
+
+
+async def test_class_has_permission(loop, test_client):
+
+    @class_has_permission('bike')
+    class BikeView(web.View):
+
+        async def get(self):
+            return web.HTTPOk()
+
+        async def post(self):
+            return web.HTTPOk()
+
+        async def put(self):
+            return web.HTTPOk()
+
+        async def patch(self):
+            return web.HTTPOk()
+
+        async def delete(self):
+            return web.HTTPOk()
+
+    class SessionView(web.View):
+        async def post(self):
+            user = self.request.match_info.get('user')
+            response = web.HTTPFound(location='/')
+            await remember(self.request, response, user)
+            return response
+
+        async def delete(self):
+            response = web.HTTPFound(location='/')
+            await forget(self.request, response)
+            return response
+
+    app = web.Application(loop=loop)
+    _setup(app, CookiesIdentityPolicy(), Autz())
+
+    app.router.add_route(
+        '*', '/permission', BikeView)
+    app.router.add_route(
+        '*', '/session/{user}', SessionView)
+
+    client = await test_client(app)
+
+    resp = await client.get('/permission')
+    assert web.HTTPUnauthorized.status_code == resp.status
+    resp = await client.post('/permission')
+    assert web.HTTPUnauthorized.status_code == resp.status
+    resp = await client.delete('/permission')
+    assert web.HTTPUnauthorized.status_code == resp.status
+
+    await client.post('/session/user_1')
+    resp = await client.get('/permission')
+    assert web.HTTPOk.status_code == resp.status
+    resp = await client.post('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.put('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.patch('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.delete('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+
+    await client.post('/session/user_2')
+    resp = await client.get('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.post('/permission')
+    assert web.HTTPOk.status_code == resp.status
+    resp = await client.put('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.patch('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.delete('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+
+    await client.post('/session/user_3')
+    resp = await client.get('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.post('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.put('/permission')
+    assert web.HTTPOk.status_code == resp.status
+    resp = await client.patch('/permission')
+    assert web.HTTPOk.status_code == resp.status
+    resp = await client.delete('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+
+    await client.post('/session/user_4')
+    resp = await client.get('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.post('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.put('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.patch('/permission')
+    assert web.HTTPForbidden.status_code == resp.status
+    resp = await client.delete('/permission')
+    assert web.HTTPOk.status_code == resp.status
+
+    await client.delete('/session/user_4')
+    resp = await client.get('/permission')
+    assert web.HTTPUnauthorized.status_code == resp.status
+    resp = await client.post('/permission')
+    assert web.HTTPUnauthorized.status_code == resp.status
+    resp = await client.put('/permission')
+    assert web.HTTPUnauthorized.status_code == resp.status
+    resp = await client.patch('/permission')
+    assert web.HTTPUnauthorized.status_code == resp.status
+    resp = await client.delete('/permission')
+    assert web.HTTPUnauthorized.status_code == resp.status


### PR DESCRIPTION
Decorator that set permission for each `aiohttp.web.View` method.

``` python
@class_has_permission(prefix='booking')
class BookingView(web.View):
     def post(self):
         """
         Require `booking.create` permission
         """

     def get(self):
         """
         Require `booking.read` permission
         """

     def put(self):
         """
         Require `booking.update` permission
         """

     def patch(self):
         """
         Require `booking.update` permission
         """

     def delete(self):
         """
         Require `booking.delete` permission
         """
```
Note: This pull request is based on https://github.com/aio-libs/aiohttp-security/pull/148 