### PR TITLE
JWTIdentityPolicy polishing

### DIFF
--- a/aiohttp_security/jwt_identity.py
+++ b/aiohttp_security/jwt_identity.py
@@ -22,7 +22,10 @@ class JWTIdentityPolicy(AbstractIdentityPolicy):
         self.algorithm = algorithm
 
     async def identify(self, request):
-        header_identity = request.headers.get(AUTH_HEADER_NAME, '')
+        header_identity = request.headers.get(AUTH_HEADER_NAME)
+
+        if header_identity is None:
+            return
 
         if not header_identity.startswith(AUTH_SCHEME):
             raise ValueError('Invalid authorization scheme. ' +

--- a/tests/test_jwt_identity.py
+++ b/tests/test_jwt_identity.py
@@ -1,10 +1,11 @@
+import jwt
 import pytest
 from aiohttp import web
-from aiohttp_security import AbstractAuthorizationPolicy
+
 from aiohttp_security import setup as _setup
-from aiohttp_security.jwt_identity import JWTIdentityPolicy
+from aiohttp_security import AbstractAuthorizationPolicy
 from aiohttp_security.api import IDENTITY_KEY
-import jwt
+from aiohttp_security.jwt_identity import JWTIdentityPolicy
 
 
 class Autz(AbstractAuthorizationPolicy):
@@ -29,7 +30,7 @@ async def test_identify(loop, test_client):
         response = web.Response()
         data = await request.post()
 
-        encoded_identity = jwt.encode({'identity': data['login']},
+        encoded_identity = jwt.encode({'login': data['login']},
                                       kwt_secret_key,
                                       algorithm='HS256')
 
@@ -38,8 +39,8 @@ async def test_identify(loop, test_client):
 
     async def check(request):
         policy = request.app[IDENTITY_KEY]
-        user_id = await policy.identify(request)
-        assert 'Andrew' == user_id
+        identity = await policy.identify(request)
+        assert 'Andrew' == identity['login']
         return web.Response()
 
     app = web.Application(loop=loop)
@@ -51,6 +52,47 @@ async def test_identify(loop, test_client):
     jwt_token = await resp.content.read()
     assert 200 == resp.status
     await resp.release()
-    headers = {'Authorization': str(jwt_token.decode('utf-8'))}
+    headers = {'Authorization': f'Bearer {jwt_token.decode("utf-8")}'}
     resp = await client.get('/', headers=headers)
     assert 200 == resp.status
+
+
+async def test_identify_broken_scheme(loop, test_client):
+
+    kwt_secret_key = 'Key'
+
+    async def create(request):
+        response = web.Response()
+        data = await request.post()
+
+        encoded_identity = jwt.encode({'login': data['login']},
+                                      kwt_secret_key,
+                                      algorithm='HS256')
+
+        response.text = encoded_identity.decode('utf-8')
+        return response
+
+    async def check(request):
+        policy = request.app[IDENTITY_KEY]
+
+        try:
+            identity = await policy.identify(request)
+        except ValueError as exc:
+            raise web.HTTPBadRequest(reason=str(exc))
+
+        assert 'Andrew' == identity['login']
+        return web.Response()
+
+    app = web.Application(loop=loop)
+    _setup(app, JWTIdentityPolicy(kwt_secret_key), Autz())
+    app.router.add_route('GET', '/', check)
+    app.router.add_route('POST', '/', create)
+    client = await test_client(app)
+    resp = await client.post('/', data={'login': 'Andrew'})
+    jwt_token = await resp.content.read()
+    assert 200 == resp.status
+    await resp.release()
+    headers = {'Authorization': f'Token {jwt_token.decode("utf-8")}'}
+    resp = await client.get('/', headers=headers)
+    assert 400 == resp.status
+    assert 'Invalid authorization scheme' in resp.reason

--- a/tests/test_jwt_identity.py
+++ b/tests/test_jwt_identity.py
@@ -8,6 +8,18 @@ from aiohttp_security.api import IDENTITY_KEY
 from aiohttp_security.jwt_identity import JWTIdentityPolicy
 
 
+@pytest.fixture
+def make_token():
+    def factory(payload, secret):
+        return jwt.encode(
+            payload,
+            secret,
+            algorithm='HS256',
+        )
+
+    return factory
+
+
 class Autz(AbstractAuthorizationPolicy):
 
     async def permits(self, identity, permission, context=None):
@@ -23,19 +35,10 @@ async def test_no_pyjwt_installed(mocker):
         JWTIdentityPolicy('secret')
 
 
-async def test_identify(loop, test_client):
+async def test_identify(loop, make_token, test_client):
     kwt_secret_key = 'Key'
 
-    async def create(request):
-        response = web.Response()
-        data = await request.post()
-
-        encoded_identity = jwt.encode({'login': data['login']},
-                                      kwt_secret_key,
-                                      algorithm='HS256')
-
-        response.text = encoded_identity.decode('utf-8')
-        return response
+    token = make_token({'login': 'Andrew'}, kwt_secret_key)
 
     async def check(request):
         policy = request.app[IDENTITY_KEY]
@@ -46,31 +49,17 @@ async def test_identify(loop, test_client):
     app = web.Application(loop=loop)
     _setup(app, JWTIdentityPolicy(kwt_secret_key), Autz())
     app.router.add_route('GET', '/', check)
-    app.router.add_route('POST', '/', create)
+
     client = await test_client(app)
-    resp = await client.post('/', data={'login': 'Andrew'})
-    jwt_token = await resp.content.read()
-    assert 200 == resp.status
-    await resp.release()
-    headers = {'Authorization': f'Bearer {jwt_token.decode("utf-8")}'}
+    headers = {'Authorization': 'Bearer {}'.format(token.decode('utf-8'))}
     resp = await client.get('/', headers=headers)
     assert 200 == resp.status
 
 
-async def test_identify_broken_scheme(loop, test_client):
-
+async def test_identify_broken_scheme(loop, make_token, test_client):
     kwt_secret_key = 'Key'
 
-    async def create(request):
-        response = web.Response()
-        data = await request.post()
-
-        encoded_identity = jwt.encode({'login': data['login']},
-                                      kwt_secret_key,
-                                      algorithm='HS256')
-
-        response.text = encoded_identity.decode('utf-8')
-        return response
+    token = make_token({'login': 'Andrew'}, kwt_secret_key)
 
     async def check(request):
         policy = request.app[IDENTITY_KEY]
@@ -78,7 +67,7 @@ async def test_identify_broken_scheme(loop, test_client):
         try:
             identity = await policy.identify(request)
         except ValueError as exc:
-            raise web.HTTPBadRequest(reason=str(exc))
+            raise web.HTTPBadRequest(reason=exc)
 
         assert 'Andrew' == identity['login']
         return web.Response()
@@ -86,13 +75,9 @@ async def test_identify_broken_scheme(loop, test_client):
     app = web.Application(loop=loop)
     _setup(app, JWTIdentityPolicy(kwt_secret_key), Autz())
     app.router.add_route('GET', '/', check)
-    app.router.add_route('POST', '/', create)
+
     client = await test_client(app)
-    resp = await client.post('/', data={'login': 'Andrew'})
-    jwt_token = await resp.content.read()
-    assert 200 == resp.status
-    await resp.release()
-    headers = {'Authorization': f'Token {jwt_token.decode("utf-8")}'}
+    headers = {'Authorization': 'Token {}'.format(token.decode('utf-8'))}
     resp = await client.get('/', headers=headers)
     assert 400 == resp.status
     assert 'Invalid authorization scheme' in resp.reason

--- a/tests/test_jwt_identity.py
+++ b/tests/test_jwt_identity.py
@@ -65,11 +65,10 @@ async def test_identify_broken_scheme(loop, make_token, test_client):
         policy = request.app[IDENTITY_KEY]
 
         try:
-            identity = await policy.identify(request)
+            await policy.identify(request)
         except ValueError as exc:
             raise web.HTTPBadRequest(reason=exc)
 
-        assert 'Andrew' == identity['login']
         return web.Response()
 
     app = web.Application(loop=loop)


### PR DESCRIPTION
What are done:
- Fixed JWTIdentityPolicy to reflect `JWT` standard.
- Minor styling improvements
- Simplified tests

Problems:
1. Jwt authorization header mostly follow such pattern `Authorization: Bearer <token>`.
Right now if you pass such header `identify` will raise jwt encoding exception cuz you pass whole `Bearer <token>` to `decode`.

2. identity key is not mandatory in payload so if you pass token with encoding information that does not have such key it will throw KeyError. It is incorrect behaviour cuz protocol does not require such field.