### PR TITLE
Generic permission

### DIFF
--- a/aiohttp_security/api.py
+++ b/aiohttp_security/api.py
@@ -1,4 +1,3 @@
-import enum
 import warnings
 from aiohttp import web
 from aiohttp_security.abc import (AbstractIdentityPolicy,
@@ -60,8 +59,6 @@ async def authorized_userid(request):
 
 
 async def permits(request, permission, context=None):
-    assert isinstance(permission, (str, enum.Enum)), permission
-    assert permission
     identity_policy = request.app.get(IDENTITY_KEY)
     autz_policy = request.app.get(AUTZ_KEY)
     if identity_policy is None or autz_policy is None:


### PR DESCRIPTION
Considering the fact `AbstractAuthorizationPolicy` does not enforce permission types, the `permits` function thus should not expect permissions to be either `str` or `enum.Enum`.
This way it is up to a developer who implement a concrete `AbstractAuthorizationPolicy` to define the type.
This will also allow managing permissions in runtime.