### PR TITLE
Move indexing back into .identify() method.

### DIFF
--- a/aiohttp_security/jwt_identity.py
+++ b/aiohttp_security/jwt_identity.py
@@ -15,11 +15,12 @@ AUTH_SCHEME = 'Bearer '
 
 
 class JWTIdentityPolicy(AbstractIdentityPolicy):
-    def __init__(self, secret, algorithm='HS256'):
+    def __init__(self, secret, algorithm='HS256', key: str = 'login'):
         if jwt is None:
             raise RuntimeError('Please install `PyJWT`')
         self.secret = secret
         self.algorithm = algorithm
+        self.key = key
 
     async def identify(self, request):
         header_identity = request.headers.get(AUTH_HEADER_NAME)
@@ -36,7 +37,7 @@ class JWTIdentityPolicy(AbstractIdentityPolicy):
         identity = jwt.decode(token,
                               self.secret,
                               algorithms=[self.algorithm])
-        return identity
+        return identity.get(self.key)
 
     async def remember(self, *args, **kwargs):  # pragma: no cover
         pass

--- a/aiohttp_security/jwt_identity.py
+++ b/aiohttp_security/jwt_identity.py
@@ -15,7 +15,7 @@ AUTH_SCHEME = 'Bearer '
 
 
 class JWTIdentityPolicy(AbstractIdentityPolicy):
-    def __init__(self, secret, algorithm='HS256', key: str = 'login'):
+    def __init__(self, secret, algorithm="HS256", key: str = "login"):
         if jwt is None:
             raise RuntimeError('Please install `PyJWT`')
         self.secret = secret

--- a/tests/test_jwt_identity.py
+++ b/tests/test_jwt_identity.py
@@ -43,7 +43,7 @@ async def test_identify(loop, make_token, aiohttp_client):
     async def check(request):
         policy = request.app[IDENTITY_KEY]
         identity = await policy.identify(request)
-        assert 'Andrew' == identity['login']
+        assert 'Andrew' == identity
         return web.Response()
 
     app = web.Application()

--- a/tests/test_jwt_identity.py
+++ b/tests/test_jwt_identity.py
@@ -43,7 +43,7 @@ async def test_identify(loop, make_token, aiohttp_client):
     async def check(request):
         policy = request.app[IDENTITY_KEY]
         identity = await policy.identify(request)
-        assert 'Andrew' == identity
+        assert "Andrew" == identity
         return web.Response()
 
     app = web.Application()


### PR DESCRIPTION
This partially reverts a change in #161, as this seems to break the API that is defined in this library. `identify()` is documented to return a `str`.