### PR TITLE
Port to Sphinx 8.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -330,5 +330,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/3': None,
-                       'http://aiohttp.readthedocs.org/en/stable': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'aiohttp': ('http://aiohttp.readthedocs.org/en/stable', None),
+}


### PR DESCRIPTION
## What do these changes do?

The old `intersphinx_mapping` format has been removed; it must now map identifiers to (target, inventory) tuples.

## Are there changes in behavior for the user?

No.

## Checklist

- [x] I think the code is well written
- [N/A] Unit tests for the changes exist
- [x] Documentation reflects the changes
