### PR TITLE
JWTIdentity raises common error JWTIdentityError

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,8 +10,9 @@ select = A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z,B901,B902,B903,B950
 # W503: Mutually exclusive with W504.
 ignore = E226,E501,E722,W503
 per-file-ignores =
+    # B011: assert False used for coverage skipping
     # S101: Pytest uses assert
-    tests/*:S101
+    tests/*:B011,S101
 
 # flake8-import-order
 application-import-names = aiohttp_security

--- a/aiohttp_security/jwt_identity.py
+++ b/aiohttp_security/jwt_identity.py
@@ -25,7 +25,7 @@ AUTH_SCHEME = 'Bearer '
 # This class inherits from ValueError to maintain backward compatibility
 # with previous versions of aiohttp-security
 class InvalidAuthorizationScheme(ValueError, *_bases_error):  # type: ignore[misc]
-    pass
+    """Exception when the auth method can't be read from header."""
 
 
 class JWTIdentityPolicy(AbstractIdentityPolicy):

--- a/aiohttp_security/jwt_identity.py
+++ b/aiohttp_security/jwt_identity.py
@@ -11,23 +11,20 @@ from .abc import AbstractIdentityPolicy
 try:
     import jwt
     HAS_JWT = True
+    _bases_error = (jwt.exceptions.PyJWTError, ValueError)
 except ImportError:  # pragma: no cover
     HAS_JWT = False
+    _bases_error = (ValueError, )
 
 
 AUTH_HEADER_NAME = 'Authorization'
 AUTH_SCHEME = 'Bearer '
 
 
-if HAS_JWT:
-    # This class inherits from ValueError to maintain backward compatibility
-    # with previous versions of aiohttp-security.
-    class JWTIdentityError(jwt.exceptions.PyJWTError, ValueError):
-        pass
-
-else:
-    class JWTIdentityError(ValueError):
-        pass
+# This class inherits from ValueError to maintain backward compatibility
+# with previous versions of aiohttp-security
+class InvalidAuthorizationScheme(*_bases_error):
+    pass
 
 
 class JWTIdentityPolicy(AbstractIdentityPolicy):
@@ -45,15 +42,14 @@ class JWTIdentityPolicy(AbstractIdentityPolicy):
             return None
 
         if not header_identity.startswith(AUTH_SCHEME):
-            raise JWTIdentityError("Invalid authorization scheme. "
-                                   + "Should be `{}<token>`".format(AUTH_SCHEME))
+            raise InvalidAuthorizationScheme("Invalid authorization scheme. "
+                                             "Should be `{}<token>`".format(AUTH_SCHEME))
 
         token = header_identity.split(' ')[1].strip()
 
         identity = jwt.decode(token,
                               self.secret,
                               algorithms=[self.algorithm])
-
         return identity.get(self.key)  # type: ignore[no-any-return]
 
     async def remember(self, request: web.Request, response: web.StreamResponse,

--- a/aiohttp_security/jwt_identity.py
+++ b/aiohttp_security/jwt_identity.py
@@ -8,10 +8,10 @@ from aiohttp import web
 
 from .abc import AbstractIdentityPolicy
 
-_bases_error: Tuple[Type[jwt.exceptions.PyJWTError], ...]
 try:
     import jwt
     HAS_JWT = True
+    _bases_error: Tuple[Type[jwt.exceptions.PyJWTError], ...]
     _bases_error = (jwt.exceptions.PyJWTError,)
 except ImportError:  # pragma: no cover
     HAS_JWT = False

--- a/aiohttp_security/jwt_identity.py
+++ b/aiohttp_security/jwt_identity.py
@@ -2,19 +2,20 @@
 
 """
 
-from typing import Optional
+from typing import Optional, Tuple, Type
 
 from aiohttp import web
 
 from .abc import AbstractIdentityPolicy
 
+_bases_error: Tuple[Type[jwt.exceptions.PyJWTError], ...]
 try:
     import jwt
     HAS_JWT = True
-    _bases_error = (jwt.exceptions.PyJWTError, ValueError)
+    _bases_error = (jwt.exceptions.PyJWTError,)
 except ImportError:  # pragma: no cover
     HAS_JWT = False
-    _bases_error = (ValueError, )
+    _bases_error = ()
 
 
 AUTH_HEADER_NAME = 'Authorization'
@@ -23,7 +24,7 @@ AUTH_SCHEME = 'Bearer '
 
 # This class inherits from ValueError to maintain backward compatibility
 # with previous versions of aiohttp-security
-class InvalidAuthorizationScheme(*_bases_error):
+class InvalidAuthorizationScheme(ValueError, *_bases_error):  # type: ignore[misc]
     pass
 
 

--- a/tests/test_jwt_identity.py
+++ b/tests/test_jwt_identity.py
@@ -85,7 +85,7 @@ async def test_identify_broken_scheme(make_token, aiohttp_client):
 async def test_identify_expired_signature(make_token, aiohttp_client):
     kwt_secret_key = "Key"  # noqa: S105
 
-    token = make_token({'login': 'Andrew', 'exp': 0}, kwt_secret_key)
+    token = make_token({"login": "Andrew", "exp": 0}, kwt_secret_key)
 
     async def check(request):
         policy = request.app[IDENTITY_KEY]
@@ -94,14 +94,14 @@ async def test_identify_expired_signature(make_token, aiohttp_client):
         except jwt.exceptions.PyJWTError as exc:
             raise web.HTTPBadRequest(reason=str(exc))
 
-        return web.Response()
+        assert False
 
     app = web.Application()
     _setup(app, JWTIdentityPolicy(kwt_secret_key), Autz())
-    app.router.add_route('GET', '/', check)
+    app.router.add_route("GET", "/", check)
 
     client = await aiohttp_client(app)
     headers = {"Authorization": "Bearer {}".format(token)}
-    resp = await client.get('/', headers=headers)
+    resp = await client.get("/", headers=headers)
     assert 400 == resp.status
-    assert 'Signature has expired' in resp.reason
+    assert "Signature has expired" in resp.reason

--- a/tests/test_jwt_identity.py
+++ b/tests/test_jwt_identity.py
@@ -80,3 +80,28 @@ async def test_identify_broken_scheme(make_token, aiohttp_client):
     resp = await client.get('/', headers=headers)
     assert 400 == resp.status
     assert 'Invalid authorization scheme' in resp.reason
+
+
+async def test_identify_expired_signature(make_token, aiohttp_client):
+    kwt_secret_key = "Key"  # noqa: S105
+
+    token = make_token({'login': 'Andrew', 'exp': 0}, kwt_secret_key)
+
+    async def check(request):
+        policy = request.app[IDENTITY_KEY]
+        try:
+            await policy.identify(request)
+        except jwt.exceptions.PyJWTError as exc:
+            raise web.HTTPBadRequest(reason=str(exc))
+
+        return web.Response()
+
+    app = web.Application()
+    _setup(app, JWTIdentityPolicy(kwt_secret_key), Autz())
+    app.router.add_route('GET', '/', check)
+
+    client = await aiohttp_client(app)
+    headers = {"Authorization": "Bearer {}".format(token)}
+    resp = await client.get('/', headers=headers)
+    assert 400 == resp.status
+    assert 'Signature has expired' in resp.reason


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Hello,

## What do these changes do?

All exceptions raised by the JWTIdentityPolicy class are subclasses of the PyJWTError type


## Are there changes in behavior for the user?

None, multiple inheritance with the old error types has been used to maintain backward compatibility.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes

note: Currently, JWTIdentityPolicy is not documented. Would you like me to add documentation and update the demo?