### PR TITLE
Return userid from check_permission

### DIFF
--- a/aiohttp_security/api.py
+++ b/aiohttp_security/api.py
@@ -103,7 +103,7 @@ async def check_authorized(request: web.Request) -> str:
 
 
 async def check_permission(request: web.Request, permission: Union[str, enum.Enum],
-                           context: Any = None) -> None:
+                           context: Any = None) -> str:
     """Checker that passes only to authoraised users with given permission.
 
     If user is not authorized - raises HTTPUnauthorized,
@@ -111,10 +111,11 @@ async def check_permission(request: web.Request, permission: Union[str, enum.Enu
     raises HTTPForbidden.
     """
 
-    await check_authorized(request)
+    userid = await check_authorized(request)
     allowed = await permits(request, permission, context)
     if not allowed:
         raise web.HTTPForbidden(reason="User does not have '{}' permission".format(permission))
+    return userid
 
 
 def setup(app: web.Application, identity_policy: AbstractIdentityPolicy,

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -86,6 +86,8 @@ Public API functions
 
    :param request:  :class:`aiohttp.web.Request` object.
 
+   :return str: authorized user ID if success
+
    :raise: :class:`aiohttp.web.HTTPUnauthorized` for anonymous users.
 
    :raise: :class:`aiohttp.web.HTTPForbidden` if user is

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -64,8 +64,10 @@ The workflow is as follows:
    :func:`authorized_userid` *be invoked* .
 4) If the user tries to access a restricted asset the :func:`permits`
    method is called.  Usually assets are protected using the
-   :func:`check_permission` helper.  This should return True if
-   permission is granted.
+   :func:`check_permission` helper, which raises
+   :class:`aiohttp.web.HTTPUnauthorized` or
+   :class:`aiohttp.web.HTTPForbidden` on failure, and returns the
+   :term:`userid` on success.
 
 The :func:`permits` method is implemented by the developer as part of
 the :class:`AbstractAuthorizationPolicy` and passed to the

--- a/tests/test_dict_autz.py
+++ b/tests/test_dict_autz.py
@@ -198,8 +198,8 @@ async def test_check_authorized(aiohttp_client):
 async def test_check_permission(aiohttp_client):
 
     async def index_read(request):
-        await check_permission(request, 'read')
-        return web.Response()
+        userid = await check_permission(request, 'read')
+        return web.Response(text=userid)
 
     async def index_write(request):
         await check_permission(request, 'write')
@@ -238,6 +238,7 @@ async def test_check_permission(aiohttp_client):
     await client.post('/login')
     resp = await client.get('/permission/read')
     assert web.HTTPOk.status_code == resp.status
+    assert "Andrew" == await resp.text()
     resp = await client.get('/permission/write')
     assert web.HTTPOk.status_code == resp.status
     resp = await client.get('/permission/forbid')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`check_permission` now returns the userid instead of None.
This avoids an extra authorization lookup for callers.

## Are there changes in behavior for the user?

These changes does not break existing logic (only adds a returned value)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
